### PR TITLE
fixing    AttributeError: 'str' object has no attribute 'get_content_…

### DIFF
--- a/gmail/message.py
+++ b/gmail/message.py
@@ -171,6 +171,8 @@ class Message():
         self.attachments = []
         def make_attachement(attachments):
             for attachment in attachments:
+                if isinstance(attachment, basestring):
+                    continue
                 if attachment.get_content_type() == 'message/rfc822':
                     make_attachement(attachment.get_payload())
                 else:


### PR DESCRIPTION
…type'

/..../gmail/message.pyc in parse(self, raw_message)
    180                         make_attachement(attachment.get_payload())
    181 
--> 182         make_attachement(self.message.get_payload())
    183 
    184 

/.../gmail/message.pyc in make_attachement(attachments)
    172         def make_attachement(attachments):
    173             for attachment in attachments:
--> 174                 if attachment.get_content_type() == 'message/rfc822':
    175                     make_attachement(attachment.get_payload())
    176                 else:

AttributeError: 'str' object has no attribute 'get_content_type'
